### PR TITLE
[ticket: #3] [fix] fix encode padding

### DIFF
--- a/Base32.js
+++ b/Base32.js
@@ -100,7 +100,7 @@ function translation(list) {
 
 function padding(str) {
     var sub = str.length % 8;
-    for (var i = 0; i < sub; i++) {
+    for (var i = 8; i < sub; i++) {
         str = str + '=';
     }
     return str;


### PR DESCRIPTION
description
エンコード時に＝の数がおかしくなる問題を解決